### PR TITLE
Correct link to code of conduct

### DIFF
--- a/governance-documents/8._Code_of_Conduct.md
+++ b/governance-documents/8._Code_of_Conduct.md
@@ -1,4 +1,4 @@
 # FINOS Code of Conduct
 
-Contributors to FINOS standards projects should follow the FINOS Code of Conduct, which can be found at: https://github.com/finos/community/blob/master/governance/Code-of-Conduct.md
+Contributors to FINOS standards projects should follow the FINOS Code of Conduct, which can be found at: https://community.finos.org/docs/governance/code-of-conduct
 


### PR DESCRIPTION
SPotted that this link has not been updated since the file moved