### PR TITLE
Renamed License

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/default.md
+++ b/.github/PULL_REQUEST_TEMPLATE/default.md
@@ -9,13 +9,13 @@ My name is <FirstName LastName> and I'd like to formally participate to the <pro
   
   By making a Contribution to this repository, I agree to the terms of the following documents located at https://github.com/finos/standards-project-blueprint/:
 
-(a) Community Specification License 1.0 (.0_Community_Specification_License-v1.md)
+(a) FINOS Specification License 1.0 (.0_Community_Specification_License-v1.md)
 
-(b) Community Specification Governance Policy 1.0 (5._Governance.md)
+(b) FINOS Specification Governance Policy 1.0 (5._Governance.md)
 
-(c) Community Specification Contribution Policy 1.0 (6._Contributing.md)
+(c) FINOS Specification Contribution Policy 1.0 (6._Contributing.md)
 
-(d) Community Specification Code of Conduct (8._Code_of_Conduct.md)
+(d) FINOS Specification Code of Conduct (8._Code_of_Conduct.md)
 
 In addition, for source code contributions, I certify that:
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-# Community Specification License 1.0
+# FINOS Specification License 1.0
 
 **The Purpose of this License.**  This License sets forth the terms under which 1) Contributor will participate in and contribute to the development of specifications, standards, best practices, guidelines, and other similar materials under this Working Group, and 2) how the materials developed under this License may be used.  It is not intended for source code.  Capitalized terms are defined in the License’s last section.
 
@@ -70,7 +70,7 @@ This patent licensing commitment does not apply to those claims subject to Contr
 
 **9.3.	Contribution.**  “Contribution” means any original work of authorship, including any modifications or additions to an existing work, that Contributor submits for inclusion in a Draft Specification, which is included in a Draft Specification or Approved Specification.
 
-**9.4.	Contributor.** “Contributor” means any person or entity that has indicated its acceptance of the License 1) by making a Contribution to the Specification, or 2) by entering into the Community Specification Contributor License Agreement for the Specification.  Contributor includes its Affiliates, assigns, agents, and successors in interest.
+**9.4.	Contributor.** “Contributor” means any person or entity that has indicated its acceptance of the License 1) by making a Contribution to the Specification, or 2) by entering into the FINOS Specification Contributor License Agreement for the Specification.  Contributor includes its Affiliates, assigns, agents, and successors in interest.
 
 **9.5.	Control.**  “Control” means direct or indirect control of more than 50% of the voting power to elect directors of that corporation, or for any other entity, the power to direct management of such entity.
 
@@ -80,7 +80,7 @@ This patent licensing commitment does not apply to those claims subject to Contr
 
 **9.8.	Implementation.**  “Implementation” means making, using, selling, offering for sale, importing or distributing any implementation of the Specification 1) only to the extent it implements the Specification and 2) so long as all required portions of the Specification are implemented.
 
-**9.9.	License.**  “License” means this Community Specification License.
+**9.9.	License.**  “License” means this FINOS Specification License.
 
 **9.10.	Licensee.**  “Licensee” means any person or entity that has indicated its acceptance of the License as set forth in Section 2.1.3.  Licensee includes its Affiliates, assigns, agents, and successors in interest.
 
@@ -94,6 +94,6 @@ This patent licensing commitment does not apply to those claims subject to Contr
 
 
 
-*The text of this Community Specification License is Copyright 2020 Joint Development Foundation and is licensed under the Creative Commons Attribution 4.0 International License available at https://creativecommons.org/licenses/by/4.0/.*
+*The text of this FINOS Specification License is Copyright 2020 Joint Development Foundation and is licensed under the Creative Commons Attribution 4.0 International License available at https://creativecommons.org/licenses/by/4.0/.*
 
 SPDX-License-Identifier: CC-BY-4.0

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -9,13 +9,13 @@ My name is <FirstName LastName> and I'd like to formally participate to the <pro
   
   By making a Contribution to this repository, I agree to the terms of the following documents located at https://github.com/finos/standards-project-blueprint/:
 
-(a) Community Specification License 1.0 (.0_Community_Specification_License-v1.md)
+(a) FINOS Specification License 1.0 (.0_Community_Specification_License-v1.md)
 
-(b) Community Specification Governance Policy 1.0 (5._Governance.md)
+(b) FINOS Specification Governance Policy 1.0 (5._Governance.md)
 
-(c) Community Specification Contribution Policy 1.0 (6._Contributing.md)
+(c) FINOS Specification Contribution Policy 1.0 (6._Contributing.md)
 
-(d) Community Specification Code of Conduct (8._Code_of_Conduct.md)
+(d) FINOS Specification Code of Conduct (8._Code_of_Conduct.md)
 
 In addition, for source code contributions, I certify that:
 

--- a/Readme.md
+++ b/Readme.md
@@ -1,16 +1,16 @@
-# Community Specification
+# FINOS Specification
 
-## What is the Community Specification For?
+## What is the FINOS Specification For?
 
-The Community Specification process is a repository-based approach for creating standards and specifications in version control systems, such as Git. 
+The FINOS Specification process is a repository-based approach for creating standards and specifications in version control systems, such as Git. 
 
 ## What is the benefit?
 
-The Community Specification allows you to start a specification development effort as easily as an open source project.  The Community Specification incorporates the terms and processes required for standards and specification development, including legal terms, intellectual property issues, due process, and governance.  It also provides the mechanisms to allow your project to grow and scale.  For example, the Community Specification provides the basis to take your specification to other standards bodies, including international standards bodies, for formal standardization if your community desires to pursue those options.
+The FINOS Specification allows you to start a specification development effort as easily as an open source project.  The FINOS Specification incorporates the terms and processes required for standards and specification development, including legal terms, intellectual property issues, due process, and governance.  It also provides the mechanisms to allow your project to grow and scale.  For example, the FINOS Specification provides the basis to take your specification to other standards bodies, including international standards bodies, for formal standardization if your community desires to pursue those options.
 
 ## How to get started?
 
-Instructions for using the Community Specification are included in the [Getting Started.md file](governance-documents/Getting%20Started.md).
+Instructions for using the FINOS Specification are included in the [Getting Started.md file](governance-documents/Getting%20Started.md).
 
 ## Could I just use an open source license for my specifications? Why should I use a specification license?
 
@@ -18,6 +18,6 @@ Open source is collaboration around a specific codebase, while specifications pr
 
 A second difference is that common open source software and specification licenses tend to have different coverage scopes for intellectual property terms. Open source licenses generally grant terms scoped only to a contributor's contributions. Specification licenses, however, generally cover implementations of the entire specification, regardless of who made the actual contribution. Because the specification will often be developed with contributions from multiple organizations, the various contributing organizations will often want to review and approve the full specification before extending patent commitments to the final, combined result. 
 
-## Who developed the Community Specification
+## Who developed the FINOS Specification
 
-The Community Specification has been developed via the [Joint Development Foundation](http://www.jointdevelopment.org), with inspiration from the [Open Web Foundation agreements](http://openwebfoundation.org) and the [Alliance for Open Media Patent License 1.0](http://aomedia.org/license/patent-license/).
+The FINOS Specification has been developed via the [Joint Development Foundation](http://www.jointdevelopment.org), with inspiration from the [Open Web Foundation agreements](http://openwebfoundation.org) and the [Alliance for Open Media Patent License 1.0](http://aomedia.org/license/patent-license/).

--- a/Readme.template.md
+++ b/Readme.template.md
@@ -27,5 +27,5 @@ Find the next meeting on the [FINOS projects calendar]({https://calendar.google.
 
 ## License
 
-This project uses the **Community Specification License 1.0** ; you can read more in the [LICENSE](LICENSE) file.
+This project uses the **FINOS Specification License 1.0** ; you can read more in the [LICENSE](LICENSE) file.
 

--- a/governance-documents/0._CS_Contributor_License_Agreement.md
+++ b/governance-documents/0._CS_Contributor_License_Agreement.md
@@ -1,14 +1,14 @@
-# Community Specification Contributor License Agreement 1.0
+# FINOS Specification Contributor License Agreement 1.0
 
 By making a Contribution to this repository, I agree to the terms of the following documents located at [https://github.com/finos/standards-project-blueprint](https://github.com/finos/standards-project-blueprint):
 
-(a) Community Specification License 1.0 (.0_Community_Specification_License-v1.md)
+(a) FINOS Specification License 1.0 (.0_Community_Specification_License-v1.md)
 
-(b) Community Specification Governance Policy 1.0 (5._Governance.md)
+(b) FINOS Specification Governance Policy 1.0 (5._Governance.md)
 
-(c) Community Specification Contribution Policy 1.0 (6._Contributing.md)
+(c) FINOS Specification Contribution Policy 1.0 (6._Contributing.md)
 
-(d) Community Specification Code of Conduct (8._Code_of_Conduct.md)
+(d) FINOS Specification Code of Conduct (8._Code_of_Conduct.md)
 
 
 In addition, for source code contributions, I certify that:

--- a/governance-documents/1._FINOS_Specification_License-v1.md
+++ b/governance-documents/1._FINOS_Specification_License-v1.md
@@ -1,4 +1,4 @@
-# Community Specification License 1.0
+# FINOS Specification License 1.0
 
 **The Purpose of this License.**  This License sets forth the terms under which 1) Contributor will participate in and contribute to the development of specifications, standards, best practices, guidelines, and other similar materials under this Working Group, and 2) how the materials developed under this License may be used.  It is not intended for source code.  Capitalized terms are defined in the License’s last section.
 
@@ -70,7 +70,7 @@ This patent licensing commitment does not apply to those claims subject to Contr
 
 **9.3.	Contribution.**  “Contribution” means any original work of authorship, including any modifications or additions to an existing work, that Contributor submits for inclusion in a Draft Specification, which is included in a Draft Specification or Approved Specification.
 
-**9.4.	Contributor.** “Contributor” means any person or entity that has indicated its acceptance of the License 1) by making a Contribution to the Specification, or 2) by entering into the Community Specification Contributor License Agreement for the Specification.  Contributor includes its Affiliates, assigns, agents, and successors in interest.
+**9.4.	Contributor.** “Contributor” means any person or entity that has indicated its acceptance of the License 1) by making a Contribution to the Specification, or 2) by entering into the FINOS Specification Contributor License Agreement for the Specification.  Contributor includes its Affiliates, assigns, agents, and successors in interest.
 
 **9.5.	Control.**  “Control” means direct or indirect control of more than 50% of the voting power to elect directors of that corporation, or for any other entity, the power to direct management of such entity.
 
@@ -80,7 +80,7 @@ This patent licensing commitment does not apply to those claims subject to Contr
 
 **9.8.	Implementation.**  “Implementation” means making, using, selling, offering for sale, importing or distributing any implementation of the Specification 1) only to the extent it implements the Specification and 2) so long as all required portions of the Specification are implemented.
 
-**9.9.	License.**  “License” means this Community Specification License.
+**9.9.	License.**  “License” means this FINOS Specification License.
 
 **9.10.	Licensee.**  “Licensee” means any person or entity that has indicated its acceptance of the License as set forth in Section 2.1.3.  Licensee includes its Affiliates, assigns, agents, and successors in interest.
 
@@ -94,6 +94,6 @@ This patent licensing commitment does not apply to those claims subject to Contr
 
 
 
-*The text of this Community Specification License is Copyright 2020 Joint Development Foundation and is licensed under the Creative Commons Attribution 4.0 International License available at https://creativecommons.org/licenses/by/4.0/.*
+*The text of this FINOS Specification License is Copyright 2020 Joint Development Foundation and is licensed under the Creative Commons Attribution 4.0 International License available at https://creativecommons.org/licenses/by/4.0/.*
 
 SPDX-License-Identifier: CC-BY-4.0

--- a/governance-documents/3._Notices.md
+++ b/governance-documents/3._Notices.md
@@ -7,9 +7,9 @@ Contact for Code of Conduct issues or inquires: legal@linuxfoundation.org
 
 ## License Acceptance
 
-Per Community Specification License 1.0 Section 2.1.3.3, Licensees may indicate their acceptance of the Community Specification License by issuing a pull request to the Specification’s repository’s Notice.md file, including the Licensee’s name, authorized individuals' names, and repository system identifier (e.g. GitHub ID), and specification version.
+Per FINOS Specification License 1.0 Section 2.1.3.3, Licensees may indicate their acceptance of the FINOS Specification License by issuing a pull request to the Specification’s repository’s Notice.md file, including the Licensee’s name, authorized individuals' names, and repository system identifier (e.g. GitHub ID), and specification version.
 
-A Licensee may consent to accepting the current Community Specification License version or any future version of the Community Specification License by indicating "or later" after their specification version.
+A Licensee may consent to accepting the current FINOS Specification License version or any future version of the FINOS Specification License by indicating "or later" after their specification version.
 
 ---------------------------------------------------------------------------------
 
@@ -31,7 +31,7 @@ Date of withdrawal:
 
 ## Exclusions
 
-This section includes any Exclusion Notices made against a Draft Deliverable or Approved Deliverable as set forth in the Community Specification Development License.  Each Exclusion Notice must include the following information:
+This section includes any Exclusion Notices made against a Draft Deliverable or Approved Deliverable as set forth in the FINOS Specification Development License.  Each Exclusion Notice must include the following information:
 
 -	Name of party making the Exclusion Notice:
 

--- a/governance-documents/4._License.md
+++ b/governance-documents/4._License.md
@@ -2,12 +2,12 @@
 
 ## Specification License
 
-Specifications in the repository are subject to the **Community Specification License 1.0** available at [https://github.com/finos/standards-project-blueprint](https://github.com/finos/standards-project-blueprint).
+Specifications in the repository are subject to the **FINOS Specification License 1.0** available at [https://github.com/finos/standards-project-blueprint](https://github.com/finos/standards-project-blueprint).
 
 ## Source Code License
 
-If source code is included in this repository, or for sample or reference code included in the specification itself, that code is subject to the [Apache-2.0 License](https://www.apache.org/licenses/LICENSE-2.0) unless otherwise designated. In the case of any conflict or confusion within this specification repository between the Community Specification License and the [Apache-2.0 License](https://www.apache.org/licenses/LICENSE-2.0) or other designated license, the terms of the Community Specification License shall apply.
+If source code is included in this repository, or for sample or reference code included in the specification itself, that code is subject to the [Apache-2.0 License](https://www.apache.org/licenses/LICENSE-2.0) unless otherwise designated. In the case of any conflict or confusion within this specification repository between the FINOS Specification License and the [Apache-2.0 License](https://www.apache.org/licenses/LICENSE-2.0) or other designated license, the terms of the FINOS Specification License shall apply.
 
 If source code is included in this repository, or for sample or reference code included in the specification itself, that code is subject to the [Apache-2.0 License](https://www.apache.org/licenses/LICENSE-2.0) unless otherwise marked.
 
-In the case of any conflict or confusion within this specification repository between the Community Specification License and the designated source code license, the terms of the Community Specification License shall apply.
+In the case of any conflict or confusion within this specification repository between the FINOS Specification License and the designated source code license, the terms of the FINOS Specification License shall apply.

--- a/governance-documents/5._Governance.md
+++ b/governance-documents/5._Governance.md
@@ -1,6 +1,6 @@
-# Community Specification Governance Policy 1.0
+# FINOS Specification Governance Policy 1.0
 
-This document provides the governance policy for specifications and other documents developed using the Community Specification process in a repository (each a “Working Group”).  Each Working Group and must adhere to the requirements in this document.
+This document provides the governance policy for specifications and other documents developed using the FINOS Specification process in a repository (each a “Working Group”).  Each Working Group and must adhere to the requirements in this document.
 
 ## 1.	Roles.
 
@@ -10,7 +10,7 @@ Each Working Group may include the following roles. Additional roles may be adop
 
 **1.2.	Editor.**  “Editors” are responsible for ensuring that the contents of the document accurately reflect the decisions that have been made by the group, and that the specification adheres to formatting and content guidelines. Each Working Group will designate an Editor for that Working Group.  A Working Group may select a new Editor upon Approval of the Working Group Participants.
 
-**1.3.	Participants.**  “Participants” are those that have made Contributions to the Working Group subject to the Community Specification License.
+**1.3.	Participants.**  “Participants” are those that have made Contributions to the Working Group subject to the FINOS Specification License.
 
 ## 2.	Decision Making.
 
@@ -20,7 +20,7 @@ Each Working Group may include the following roles. Additional roles may be adop
 
 ## 3.	Ways of Working.
 
-Inspired by [ANSI’s Essential Requirements for Due Process](https://share.ansi.org/Shared%20Documents/Standards%20Activities/American%20National%20Standards/Procedures,%20Guides,%20and%20Forms/2020_ANSI_Essential_Requirements.pdf), Community Specification Working Groups must adhere to consensus-based due process requirements.  These requirements apply to activities related to the development of consensus for approval, revision, reaffirmation, and withdrawal of Community Specifications.  Due process means that any person (organization, company, government agency, individual, etc.) with a direct and material interest has a right to participate by: a) expressing a position and its basis, b) having that position considered, and c) having the right to appeal. Due process allows for equity and fair play. The following constitute the minimum acceptable due process requirements for the development of consensus.
+Inspired by [ANSI’s Essential Requirements for Due Process](https://share.ansi.org/Shared%20Documents/Standards%20Activities/American%20National%20Standards/Procedures,%20Guides,%20and%20Forms/2020_ANSI_Essential_Requirements.pdf), FINOS Specification Working Groups must adhere to consensus-based due process requirements.  These requirements apply to activities related to the development of consensus for approval, revision, reaffirmation, and withdrawal of FINOS Specifications.  Due process means that any person (organization, company, government agency, individual, etc.) with a direct and material interest has a right to participate by: a) expressing a position and its basis, b) having that position considered, and c) having the right to appeal. Due process allows for equity and fair play. The following constitute the minimum acceptable due process requirements for the development of consensus.
 
 **3.1.	Openness.**  Participation shall be open to all persons who are directly and materially affected by the activity in question. There shall be no undue financial barriers to participation. Voting membership on the consensus body shall not be conditional upon membership in any organization, nor unreasonably restricted on the basis of technical qualifications or other such requirements.  Membership in a Working Group’s parent organization, if any, may be required.
 
@@ -32,7 +32,7 @@ Inspired by [ANSI’s Essential Requirements for Due Process](https://share.ansi
 
 **3.5.	Consideration of Views and Objections.**  Prompt consideration shall be given to the written views and objections of all Participants.
 
-**3.6.	Written procedures.**  This governance document and other materials documenting the Community Specification development process shall be available to any interested person.
+**3.6.	Written procedures.**  This governance document and other materials documenting the FINOS Specification development process shall be available to any interested person.
 
 ## 4.	Specification Development Process.  
 

--- a/governance-documents/6._Contributing.md
+++ b/governance-documents/6._Contributing.md
@@ -1,6 +1,6 @@
-# Community Specification Contribution Policy 1.0
+# FINOS Specification Contribution Policy 1.0
 
-This document provides the contribution policy for specifications and other documents developed using the Community Specification process in a repository (each a “Working Group”).  Additional or alternate contribution policies may be adopted and documented by the Working Group.
+This document provides the contribution policy for specifications and other documents developed using the FINOS Specification process in a repository (each a “Working Group”).  Additional or alternate contribution policies may be adopted and documented by the Working Group.
 
 ## 1.	Contribution Guidelines. 
 

--- a/governance-documents/7._CS_Template.md
+++ b/governance-documents/7._CS_Template.md
@@ -1,6 +1,6 @@
-# Community Specification Template 1.0
+# FINOS Specification Template 1.0
 
-Community Specifications are recommended to be drafted in accordance with international best practices.  Doing so provides clarity, helps adoption, and also eases the transition of this specification to other standards body if so desired.  Accordingly, the recommended template below is based on ISO standard drafting conventions.
+FINOS Specifications are recommended to be drafted in accordance with international best practices.  Doing so provides clarity, helps adoption, and also eases the transition of this specification to other standards body if so desired.  Accordingly, the recommended template below is based on ISO standard drafting conventions.
 
 To help you, this guide on writing standards was produced by the ISO/TMB and is available at https://www.iso.org/iso/how-to-write-standards.pdf.
 
@@ -16,7 +16,7 @@ In addition, we recommend using the key words "MUST", "MUST NOT", "REQUIRED", "S
  
 © _________________
 
-This specification is subject to the Community Specification License 1.0, available at [https://github.com/CommunitySpecification/1.0](https://github.com/CommunitySpecification/1.0).
+This specification is subject to the FINOS Specification License 1.0, available at [https://github.com/CommunitySpecification/1.0](https://github.com/CommunitySpecification/1.0).
 
  
 

--- a/governance-documents/Getting Started.md
+++ b/governance-documents/Getting Started.md
@@ -1,18 +1,18 @@
-# Using the Community Specification License for your Specification Development Project
+# Using the FINOS Specification License for your Specification Development Project
 
-## 1. Option 1 - Reference the Official Community Specification Repository
+## 1. Option 1 - Reference the Official FINOS Specification Repository
 
 ### Step 1.
 
-Create a new repository and include the following files from the FINOS version of the Community Specification 1.0 repository [https://github.com/finos/standards-project-blueprint](https://github.com/finos/standards-project-blueprint):
+Create a new repository and include the following files from the FINOS version of the FINOS Specification 1.0 repository [https://github.com/finos/standards-project-blueprint](https://github.com/finos/standards-project-blueprint):
 
-- **Community Specification Contributor License Agreement.**  The Community Specification Contributor License Agreement is the agreement that binds participants to the legal and governance terms established for the Working Group, and it binds participants to those terms, governance, and agreements in the official Community Specification repository. This ensures consistency for all projects using these agreements and avoids the risk that the terms have been modified. 
+- **FINOS Specification Contributor License Agreement.**  The FINOS Specification Contributor License Agreement is the agreement that binds participants to the legal and governance terms established for the Working Group, and it binds participants to those terms, governance, and agreements in the official FINOS Specification repository. This ensures consistency for all projects using these agreements and avoids the risk that the terms have been modified. 
 
-- **Scope.md.**  The Scope.md file determines the scope of your Working Group. Items beyond that scope are not subject to licensing obligations established by the Community Specification License.    
+- **Scope.md.**  The Scope.md file determines the scope of your Working Group. Items beyond that scope are not subject to licensing obligations established by the FINOS Specification License.    
 
 - **Notices.md.**  The Notices.md file includes information and notices about the Working Group, including contacts for code of conduct issues, patent exclusions, parties that have specifically notified the community that they are implementing the specification, and parties that have withdrawn from the Working Group.
 
-- **License.md.**  The License.md file includes a statement notifying people that the project is under the Community Specification License, and the license for any source code included with the specification.
+- **License.md.**  The License.md file includes a statement notifying people that the project is under the FINOS Specification License, and the license for any source code included with the specification.
 
 ### Step 2.
 
@@ -28,11 +28,11 @@ Fill in the required information.
 
 Develop your specification in that repository. 
 
-## Option 2 - Clone the Community Specification Repository
+## Option 2 - Clone the FINOS Specification Repository
 
 ### Step 1.
 
-Clone the Community Specification 1.0 repository [https://github.com/finos/standards-project-blueprint](https://github.com/finos/standards-project-blueprint) into your new repository.
+Clone the FINOS Specification 1.0 repository [https://github.com/finos/standards-project-blueprint](https://github.com/finos/standards-project-blueprint) into your new repository.
 
 ### Step 2.
 
@@ -50,14 +50,14 @@ Develop your specification in that repository.
 
 # Best Practices.
 
-1. **Enrollment via PR or CLA bot.** Ensure that all contributors submit a Pull Request accepting the License terms, using the provided [template](https://github.com/finos/standards-project-blueprint/blob/master/.github/PULL_REQUEST_TEMPLATE/enrollment_pull_request_template.md). Alternatively, enable the EasyCLA bot to require a **Community Specification Contributor License Agreement** be signed (either by an individual contributor or by a contributor's employer, which covers the employed contributor) and in place prior to making any contribution. A project should choose and enforce only one of the above approaches for that standards project, i.e. all contributors sign a CLA or all contributors submit a PR, but not a mix of both.
+1. **Enrollment via PR or CLA bot.** Ensure that all contributors submit a Pull Request accepting the License terms, using the provided [template](https://github.com/finos/standards-project-blueprint/blob/master/.github/PULL_REQUEST_TEMPLATE/enrollment_pull_request_template.md). Alternatively, enable the EasyCLA bot to require a **FINOS Specification Contributor License Agreement** be signed (either by an individual contributor or by a contributor's employer, which covers the employed contributor) and in place prior to making any contribution. A project should choose and enforce only one of the above approaches for that standards project, i.e. all contributors sign a CLA or all contributors submit a PR, but not a mix of both.
 
-1. **Use for specifications, not code.**  Use the Community Specification License for specification development, not code.
+1. **Use for specifications, not code.**  Use the FINOS Specification License for specification development, not code.
 
 1. **Scope.** Draft the scope with care since it sets the outer bounds of the patent commitments participants make to the specification.  If you draft it too narrowly, you may limit the functionality of the specification, especially as the project progresses.  Draft it too broadly and it may provide a barrier to participation since participants may be unwilling to agree to potentially broad patent commitments.  For guidance on drafting an appropriate Scope, you may find [ISO's guidance (see page 5)](https://www.iso.org/files/live/sites/isoorg/files/archive/pdf/en/how-to-write-standards.pdf "ISO How To Write Standards Guide") helpful.
 
-1.  **Specification format.**  Where appropriate, use the Community Specification Template to draft your specification.
+1.  **Specification format.**  Where appropriate, use the FINOS Specification Template to draft your specification.
 
-1. **Develop specifications and code in separate repositories.**  Where possible, separate specifications and source code into different repositories, with the specifications under the Community Specification License and the source code under an OSI-approved open source license.  
+1. **Develop specifications and code in separate repositories.**  Where possible, separate specifications and source code into different repositories, with the specifications under the FINOS Specification License and the source code under an OSI-approved open source license.  
 
 1. **Develop multiple specifications in separate repositories.** When developing multiple specifications, each individual specification should be in its own repository.

--- a/governance-documents/participants.md
+++ b/governance-documents/participants.md
@@ -1,5 +1,5 @@
 # Participants enrolled in the {standard name} project
-Below is the list of [participants](governance-documents/5._Governance.md#1roles) in the CML Reference Data standard, who have committed to the [Community Specification Contributor License Agreement](governance-documents/0._CS_Contributor_License_Agreement.md).
+Below is the list of [participants](governance-documents/5._Governance.md#1roles) in the CML Reference Data standard, who have committed to the [FINOS Specification Contributor License Agreement](governance-documents/0._CS_Contributor_License_Agreement.md).
 
 ## Participants
 - Name, organization, Date of enrollment: MMM/DD/YYYY


### PR DESCRIPTION
After discussion around FDC3 licensing with Kris and Scott, Scott said that if we wanted to have any changes to the Community Specification License, we would need to rename it to the FINOS Specification License.
